### PR TITLE
Add support for npm lockfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Found 1 duplicate dependency
 @material/animation with versions 3.1.0, 4.0.0.
 ```
 
+### npm projects
+
+```
+npx diglett npm <optional path to project>
+```
+
 ### Yarn projects
 
 ```
@@ -34,10 +40,6 @@ By default all workspace packages are analyzed. If you just want to analyze one,
 | `--dev`            | Also checks packages in the `devDependencies` field.           | _false_     |
 | `--optional`       | Also checks packages in the `optionalDependencies` field.      | _false_     |
 | `--peer`           | Also checks packages in the `peerDependencies` field.          | _false_     |
-
-## Limitations
-
-Currently the project only supports projects with `yarn.lock` files.
 
 ## Prior work
 

--- a/src/commands/npm.js
+++ b/src/commands/npm.js
@@ -1,15 +1,15 @@
 const path = require('path');
 const sharedArguments = require('../sharedArguments');
-const { readYarnLockfile, readPackageJSON } = require('../fs');
-const groupYarnDependencies = require('../groupYarnDependencies');
+const { readNpmLockfile, readPackageJSON } = require('../fs');
+const groupNpmDependencies = require('../groupNpmDependencies');
 const getDuplicateDependencies = require('../getDuplicateDependencies');
 const getPackageDependencies = require('../getPackageDependencies');
 const getDependencyGroupsFromArgv = require('../getDependencyGroupsFromArgv');
 const printResult = require('../printResult');
 
-exports.command = 'yarn [project-path]';
+exports.command = 'npm [project-path]';
 
-exports.describe = 'Check regular yarn project';
+exports.describe = 'Check npm project';
 
 exports.builder = {
   ...sharedArguments,
@@ -18,7 +18,7 @@ exports.builder = {
 exports.handler = function(argv) {
   const projectPath = path.resolve(argv.projectPath || './');
   const packageJSON = readPackageJSON(projectPath);
-  const lockfile = readYarnLockfile(projectPath);
+  const lockfile = readNpmLockfile(projectPath);
   const dependencyGroups = getDependencyGroupsFromArgv(argv);
 
   const packageDependencies = getPackageDependencies(
@@ -26,7 +26,7 @@ exports.handler = function(argv) {
     dependencyGroups
   );
 
-  const groupedVersions = groupYarnDependencies(packageDependencies, lockfile);
+  const groupedVersions = groupNpmDependencies(packageDependencies, lockfile);
 
   const duplicates = getDuplicateDependencies(groupedVersions, argv.filter);
 

--- a/src/commands/yarn-workspace.js
+++ b/src/commands/yarn-workspace.js
@@ -3,11 +3,11 @@ const path = require('path');
 const glob = require('glob');
 const sharedArguments = require('../sharedArguments');
 const { InvalidProjectTypeError, InvalidArgumentError } = require('../errors');
-const { readLockfile, readPackageJSON } = require('../fs');
+const { readYarnLockfile, readPackageJSON } = require('../fs');
 const getDuplicateDependencies = require('../getDuplicateDependencies');
 const getPackageDependencies = require('../getPackageDependencies');
 const getDependencyGroupsFromArgv = require('../getDependencyGroupsFromArgv');
-const groupResolvedDependencies = require('../groupResolvedDependencies');
+const groupYarnDependencies = require('../groupYarnDependencies');
 const printResult = require('../printResult');
 
 exports.command = 'yarn-workspace [project-path]';
@@ -63,7 +63,7 @@ function getWorkspaceDependencies(
 exports.handler = function(argv) {
   const projectPath = path.resolve(argv.projectPath || './');
   const packageJSON = readPackageJSON(projectPath);
-  const lockfile = readLockfile(projectPath);
+  const lockfile = readYarnLockfile(projectPath);
   const dependencyGroups = getDependencyGroupsFromArgv(argv);
 
   const { workspaces } = packageJSON;
@@ -107,7 +107,7 @@ exports.handler = function(argv) {
     .map(omit(packageNames))
     .reduce(
       (acc, packageDependencies) =>
-        groupResolvedDependencies(packageDependencies, lockfile, acc),
+        groupYarnDependencies(packageDependencies, lockfile, acc),
       new Map()
     );
 

--- a/src/fs.js
+++ b/src/fs.js
@@ -6,14 +6,21 @@ const { FileNotFoundError, ParseError } = require('./errors');
 function readFile(fileName, projectPath) {
   const filePath = path.join(projectPath, fileName);
   if (!fs.existsSync(filePath)) {
-    throw new FileNotFoundError(
-      `File ${fileName} not found in ${projectPath}. Please supply a valid path to a yarn project.`
-    );
+    throw new FileNotFoundError(`File ${fileName} not found in ${projectPath}`);
   }
   return fs.readFileSync(filePath, 'utf8');
 }
 
-function readLockfile(projectPath) {
+function readJSON(fileName, projectPath) {
+  const file = readFile(fileName, projectPath);
+  try {
+    return JSON.parse(file);
+  } catch {
+    throw new ParseError(`Failed to parse ${fileName}`);
+  }
+}
+
+function readYarnLockfile(projectPath) {
   const file = readFile('yarn.lock', projectPath);
   const parsed = lockfile.parse(file);
   if (parsed.type !== 'success') {
@@ -23,15 +30,15 @@ function readLockfile(projectPath) {
 }
 
 function readPackageJSON(projectPath) {
-  const file = readFile('package.json', projectPath);
-  try {
-    return JSON.parse(file);
-  } catch {
-    throw new ParseError('Failed to parse package.json');
-  }
+  return readJSON('package.json', projectPath);
+}
+
+function readNpmLockfile(projectPath) {
+  return readJSON('package-lock.json', projectPath);
 }
 
 module.exports = {
-  readLockfile,
+  readYarnLockfile,
+  readNpmLockfile,
   readPackageJSON,
 };

--- a/src/getDuplicateDependencies.js
+++ b/src/getDuplicateDependencies.js
@@ -1,4 +1,4 @@
-const groupResolvedDependencies = require('./groupResolvedDependencies');
+const groupYarnDependencies = require('./groupYarnDependencies');
 
 function getDuplicateDependencies(groupedVersions, packageNamePattern) {
   const duplicates = new Map();

--- a/src/graph/buildNpmLockfileGraph.js
+++ b/src/graph/buildNpmLockfileGraph.js
@@ -1,0 +1,58 @@
+const createDependencyNode = require('./createDependencyNode');
+
+const findDependency = (name, node) => {
+  if (node) {
+    if (node.children.has(name)) {
+      return node.children.get(name);
+    }
+    return findDependency(name, node.parent);
+  }
+  return null;
+};
+
+const resolveAndPopulateRequires = (node, requires) => {
+  if (requires) {
+    for (const name in requires) {
+      const dependencyNode = findDependency(name, node);
+      if (!dependencyNode) {
+        throw new Error(`Dependency ${name} not found`);
+      }
+      node.children.set(name, dependencyNode);
+    }
+  }
+  return node;
+};
+
+const populateDependencyNodes = (node, dependencies) => {
+  for (const name in dependencies) {
+    const dependency = dependencies[name];
+    const child = createDependencyNode(name, dependency.version, node);
+    node.children.set(name, child);
+    if (dependency.dependencies) {
+      populateDependencyNodes(child, dependency.dependencies);
+    }
+  }
+  return node;
+};
+
+const populateRequireNodes = (node, dependency) => {
+  node.children.forEach((child, name) => {
+    populateRequireNodes(child, dependency.dependencies[name]);
+  });
+  resolveAndPopulateRequires(node, dependency.requires);
+
+  return node;
+};
+
+const buildNpmLockfileGraph = lockfile => {
+  const node = createDependencyNode(lockfile.name);
+  const { dependencies } = lockfile;
+  populateDependencyNodes(node, dependencies);
+  for (const name in dependencies) {
+    const child = node.children.get(name);
+    populateRequireNodes(child, dependencies[name]);
+  }
+  return node;
+};
+
+module.exports = buildNpmLockfileGraph;

--- a/src/graph/createDependencyNode.js
+++ b/src/graph/createDependencyNode.js
@@ -1,0 +1,8 @@
+module.exports = function createDependencyNode(
+  name,
+  version,
+  parent = null,
+  children = new Map()
+) {
+  return { name, version, parent, children };
+};

--- a/src/groupNpmDependencies.js
+++ b/src/groupNpmDependencies.js
@@ -1,0 +1,33 @@
+const buildNpmLockfileGraph = require('./graph/buildNpmLockfileGraph');
+
+const populateVersions = (dependency, installedVersions = new Map()) => {
+  if (!installedVersions.has(dependency.name)) {
+    installedVersions.set(dependency.name, new Set());
+  }
+
+  const versions = installedVersions.get(dependency.name);
+
+  if (!versions.has(dependency.version)) {
+    versions.add(dependency.version);
+    dependency.children.forEach(child => {
+      populateVersions(child, installedVersions);
+    });
+  }
+
+  return installedVersions;
+};
+
+function groupNpmDependencies(packageDependencies, lockfile) {
+  const graph = buildNpmLockfileGraph(lockfile);
+
+  const versions = new Map();
+
+  for (const packageName in packageDependencies) {
+    const dependency = graph.children.get(packageName);
+    populateVersions(dependency, versions);
+  }
+
+  return versions;
+}
+
+module.exports = groupNpmDependencies;

--- a/src/groupYarnDependencies.js
+++ b/src/groupYarnDependencies.js
@@ -1,4 +1,4 @@
-function groupResolvedDependencies(
+function groupYarnDependencies(
   packageDependencies,
   resolvedDependencies,
   collection
@@ -48,4 +48,4 @@ function groupResolvedDependencies(
   return versions;
 }
 
-module.exports = groupResolvedDependencies;
+module.exports = groupYarnDependencies;

--- a/test/fixtures/dev-dependencies/package-lock.json
+++ b/test/fixtures/dev-dependencies/package-lock.json
@@ -1,0 +1,279 @@
+{
+  "name": "diglett-dev-dependencies",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@material/animation": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-4.0.0.tgz",
+      "integrity": "sha512-IfzXzstWdtKQcsNWu+s2Hpz5dBwkTHtgtzoesr+FC7TqENH+SJdsF1ntnZI1XVi2C9ZlBf7f4BSmXpWHD0MIlw==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@material/base": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-4.0.0.tgz",
+      "integrity": "sha512-vHm7fkqXzjdfxifXvlmaZColoIfKuWmO+1rvdzDORTWP+A8Dq70cgKd2I1SBqxzDGjOasMzHbQI6f9MISQf2vQ==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@material/button": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@material/button/-/button-3.2.0.tgz",
+      "integrity": "sha512-VEASy3Dtc7BCo8/cuUIp6w0+/l4U1myGZffK5GeFVInP/erStSQOmYXT7jGXkZpUglRzWOpVvEpc6nsvhMqGbw==",
+      "dev": true,
+      "requires": {
+        "@material/elevation": "^3.1.0",
+        "@material/feature-targeting": "^3.1.0",
+        "@material/ripple": "^3.2.0",
+        "@material/rtl": "^3.2.0",
+        "@material/shape": "^3.1.0",
+        "@material/theme": "^3.1.0",
+        "@material/typography": "^3.1.0"
+      },
+      "dependencies": {
+        "@material/animation": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@material/animation/-/animation-3.1.0.tgz",
+          "integrity": "sha512-ZfP95awrPBLhpaCTPNx+xKYPp2D88fzf5p5YNVp6diUAGRpq3g12Aq7qJfIHDXAFo5CtrYhgOKRqIKxUVcFisQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/base": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@material/base/-/base-3.1.0.tgz",
+          "integrity": "sha512-pWEBHyPrMV3rdnjqWWH96h5t3MxQI6V1J9jOor+UBG7bXQtr6InTabTqhz5CLY7r+qZU8YvNh2OKIy8heP0cyQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/dom": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@material/dom/-/dom-3.1.0.tgz",
+          "integrity": "sha512-RtBLSkrBjMfHwknaGBifAIC8cBWF9pXjz2IYqfI2braB6SfQI4vhdJviwyiA5BmA/psn3cKpBUZbHI0ym0O0SQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-3.1.0.tgz",
+          "integrity": "sha512-aXAa1Pv6w32URacE9LfMsl9zI6hFwx1K0Lp3Xpyf4rAkmaAB6z0gOkhicOrVFc0f64YheJgHjE7hJFieVenQdw==",
+          "dev": true
+        },
+        "@material/ripple": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-3.2.0.tgz",
+          "integrity": "sha512-GtwkfNakALmfGLs6TpdFIVeAWjRqbyT7WfEw9aU7elUokABfHES+O0KoSKQSMQiSQ8Vjl90MONzNsN1Evi/1YQ==",
+          "dev": true,
+          "requires": {
+            "@material/animation": "^3.1.0",
+            "@material/base": "^3.1.0",
+            "@material/dom": "^3.1.0",
+            "@material/feature-targeting": "^3.1.0",
+            "@material/theme": "^3.1.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/rtl": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-3.2.0.tgz",
+          "integrity": "sha512-L/w9m9Yx1ceOw/VjEfeJoqD4rW9QP3IBb9MamXAg3qUi/zsztoXD/FUw179pxkLn4huFFNlVYZ4Y1y6BpM0PMA==",
+          "dev": true
+        },
+        "@material/shape": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@material/shape/-/shape-3.1.0.tgz",
+          "integrity": "sha512-Oyvs7YjHfByA0e9IVVp7ojAlPwgSu3Bl0cioiE0OdkidkAaNu0izM2ryRzMBDH5o8+lRD0kpZoT+9CVVCdaYIg==",
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^3.1.0"
+          }
+        },
+        "@material/theme": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-3.1.0.tgz",
+          "integrity": "sha512-N4JX+akOwg1faAvFvIEhDcwW4cZfUpwEn8lct6Vs3WczjLF6/KdIoLVaYh+eVl1bzfsoIuWvx56j0B1PjXZw9g==",
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^3.1.0"
+          }
+        },
+        "@material/typography": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@material/typography/-/typography-3.1.0.tgz",
+          "integrity": "sha512-aSNBQvVxIH1kORSYdLGuSTivx6oJ1MSOSTUAsUwhXPQLQlvbdFeZaqUp7xgn+EvRsHGRFhWk5YGuiBds9+7zQg==",
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^3.1.0"
+          }
+        }
+      }
+    },
+    "@material/density": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/density/-/density-4.0.0.tgz",
+      "integrity": "sha512-PuOCPCXlWjimTq+OuCS8biAb1JE9aXCZwT1dRG9REAIAK7bN8KeeTzkeJp6jTj+ggZjWphwKF0lKeX6Gv+e/lw=="
+    },
+    "@material/dom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-4.0.0.tgz",
+      "integrity": "sha512-GRCJT9+PGWqygZwGf1XLTrbmzP35YWG7+T0hpfhoIJO8VDiMTeyfvhJXFuA2wh9pD0noEjte0lmbdBlykrbWZw==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@material/elevation": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-3.1.0.tgz",
+      "integrity": "sha512-e45LqiG6LfbR1M52YkSLA7pQPeYJOuOVzLp27xy2072TnLuJexMxhEaG4O1novEIjsTtMjqfrfJ/koODU5vEew==",
+      "dev": true,
+      "requires": {
+        "@material/animation": "^3.1.0",
+        "@material/feature-targeting": "^3.1.0",
+        "@material/theme": "^3.1.0"
+      },
+      "dependencies": {
+        "@material/animation": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@material/animation/-/animation-3.1.0.tgz",
+          "integrity": "sha512-ZfP95awrPBLhpaCTPNx+xKYPp2D88fzf5p5YNVp6diUAGRpq3g12Aq7qJfIHDXAFo5CtrYhgOKRqIKxUVcFisQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-3.1.0.tgz",
+          "integrity": "sha512-aXAa1Pv6w32URacE9LfMsl9zI6hFwx1K0Lp3Xpyf4rAkmaAB6z0gOkhicOrVFc0f64YheJgHjE7hJFieVenQdw==",
+          "dev": true
+        },
+        "@material/theme": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-3.1.0.tgz",
+          "integrity": "sha512-N4JX+akOwg1faAvFvIEhDcwW4cZfUpwEn8lct6Vs3WczjLF6/KdIoLVaYh+eVl1bzfsoIuWvx56j0B1PjXZw9g==",
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^3.1.0"
+          }
+        }
+      }
+    },
+    "@material/feature-targeting": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-4.0.0.tgz",
+      "integrity": "sha512-0gk+f151vqmEdWkrQ9ocPlQRU9aUtSGsVBhletqIbsthLUsZIz9qk25FHjV1wHd/bGHknd9NH+T8ENprv3KLFg=="
+    },
+    "@material/floating-label": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-4.0.0.tgz",
+      "integrity": "sha512-ovuZKhH7U+YmZk8kXftYCdEaU9InJdkBsPe4TP+dg4HiO1lWmd7ZxVsMo6iTl4yaFofkBPj3VDkbE1fLnHxKPA==",
+      "requires": {
+        "@material/animation": "^4.0.0",
+        "@material/base": "^4.0.0",
+        "@material/rtl": "^4.0.0",
+        "@material/theme": "^4.0.0",
+        "@material/typography": "^4.0.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@material/line-ripple": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-4.0.0.tgz",
+      "integrity": "sha512-+vrgKlb2gUBIKxlzVKLn/tX76qJ0Z19RkH2i7mh4IdH8KxeEai8NQQYWqeOOKtyp8JbH0ObGyqJCwPo2VbHDmw==",
+      "requires": {
+        "@material/animation": "^4.0.0",
+        "@material/base": "^4.0.0",
+        "@material/theme": "^4.0.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@material/notched-outline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-4.0.0.tgz",
+      "integrity": "sha512-9WNG7dZS83nu72kmoknA3XyvZQIxx8QBjEB2Q2KGyRp4Q8zrzWxfcvTYgiOsYgvz013JnTqaqe4g0wjl6v789g==",
+      "requires": {
+        "@material/base": "^4.0.0",
+        "@material/floating-label": "^4.0.0",
+        "@material/rtl": "^4.0.0",
+        "@material/shape": "^4.0.0",
+        "@material/theme": "^4.0.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@material/ripple": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-4.0.0.tgz",
+      "integrity": "sha512-9BLIOvyCP5sM+fQpLlcJZWyrHguusJq8E5A1pxg0wQwputOyaPBM7recHhYkJmVjzRpTcPgf1PkvkpN6DKGcNg==",
+      "requires": {
+        "@material/animation": "^4.0.0",
+        "@material/base": "^4.0.0",
+        "@material/dom": "^4.0.0",
+        "@material/feature-targeting": "^4.0.0",
+        "@material/theme": "^4.0.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@material/rtl": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-4.0.0.tgz",
+      "integrity": "sha512-AP8zByVDEWAJVJoxByVccUbH+BX24IeG7ol+L6Qd8JjzPpz1fzPVJ4BeDNaF0a6sXtHsRmj2zN5dsx/BGC3IHg=="
+    },
+    "@material/shape": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-4.0.0.tgz",
+      "integrity": "sha512-wmr05YBrEL462QPiJ+t9xh5RqxzylXYo/8DVZnb/1WA9GZ6m38UK/8Awtip1cZAN34pzD/9p5AydyywlQVoI+g==",
+      "requires": {
+        "@material/feature-targeting": "^4.0.0"
+      }
+    },
+    "@material/textfield": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-4.0.0.tgz",
+      "integrity": "sha512-1Xg+nriTqFB8+5k8sGkR8LBeD3dRgNuhvwyU8XrUeAs5l/HMfn4CWgbEyZTaJ2EEtFPxnKGedAYqCEwXngwGWg==",
+      "requires": {
+        "@material/animation": "^4.0.0",
+        "@material/base": "^4.0.0",
+        "@material/density": "^4.0.0",
+        "@material/dom": "^4.0.0",
+        "@material/floating-label": "^4.0.0",
+        "@material/line-ripple": "^4.0.0",
+        "@material/notched-outline": "^4.0.0",
+        "@material/ripple": "^4.0.0",
+        "@material/rtl": "^4.0.0",
+        "@material/shape": "^4.0.0",
+        "@material/theme": "^4.0.0",
+        "@material/typography": "^4.0.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@material/theme": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-4.0.0.tgz",
+      "integrity": "sha512-vS4G4rusJTatTH50kSYO1U3UGN8EY9kGRvPaFsEFKikJBOqcR6KWK9H9/wCLqqd6nDNifEj9H2sdWw1AV4NA6Q==",
+      "requires": {
+        "@material/feature-targeting": "^4.0.0"
+      }
+    },
+    "@material/typography": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-4.0.0.tgz",
+      "integrity": "sha512-lUG4yjG9fl1ryNX4OVnOmi+EjhiV4WsWcYt4yzffHrFg1RfKuCAV59j7TtmlMfZIkNDwqK5jvk3oOpTRDFpL8Q==",
+      "requires": {
+        "@material/feature-targeting": "^4.0.0"
+      }
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    }
+  }
+}

--- a/test/fixtures/no-lockfile/package.json
+++ b/test/fixtures/no-lockfile/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "diglett-no-lockfile",
+  "private": true,
+  "dependencies": {
+    "@material/button": "^3.2.0",
+    "@material/textfield": "^4.0.0"
+  }
+}

--- a/test/fixtures/regular/package-lock.json
+++ b/test/fixtures/regular/package-lock.json
@@ -1,0 +1,353 @@
+{
+  "name": "diglett-regular",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@material/animation": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-3.1.0.tgz",
+      "integrity": "sha512-ZfP95awrPBLhpaCTPNx+xKYPp2D88fzf5p5YNVp6diUAGRpq3g12Aq7qJfIHDXAFo5CtrYhgOKRqIKxUVcFisQ==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@material/base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-3.1.0.tgz",
+      "integrity": "sha512-pWEBHyPrMV3rdnjqWWH96h5t3MxQI6V1J9jOor+UBG7bXQtr6InTabTqhz5CLY7r+qZU8YvNh2OKIy8heP0cyQ==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@material/button": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@material/button/-/button-3.2.0.tgz",
+      "integrity": "sha512-VEASy3Dtc7BCo8/cuUIp6w0+/l4U1myGZffK5GeFVInP/erStSQOmYXT7jGXkZpUglRzWOpVvEpc6nsvhMqGbw==",
+      "requires": {
+        "@material/elevation": "^3.1.0",
+        "@material/feature-targeting": "^3.1.0",
+        "@material/ripple": "^3.2.0",
+        "@material/rtl": "^3.2.0",
+        "@material/shape": "^3.1.0",
+        "@material/theme": "^3.1.0",
+        "@material/typography": "^3.1.0"
+      }
+    },
+    "@material/density": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/density/-/density-4.0.0.tgz",
+      "integrity": "sha512-PuOCPCXlWjimTq+OuCS8biAb1JE9aXCZwT1dRG9REAIAK7bN8KeeTzkeJp6jTj+ggZjWphwKF0lKeX6Gv+e/lw=="
+    },
+    "@material/dom": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-3.1.0.tgz",
+      "integrity": "sha512-RtBLSkrBjMfHwknaGBifAIC8cBWF9pXjz2IYqfI2braB6SfQI4vhdJviwyiA5BmA/psn3cKpBUZbHI0ym0O0SQ==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@material/elevation": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-3.1.0.tgz",
+      "integrity": "sha512-e45LqiG6LfbR1M52YkSLA7pQPeYJOuOVzLp27xy2072TnLuJexMxhEaG4O1novEIjsTtMjqfrfJ/koODU5vEew==",
+      "requires": {
+        "@material/animation": "^3.1.0",
+        "@material/feature-targeting": "^3.1.0",
+        "@material/theme": "^3.1.0"
+      }
+    },
+    "@material/feature-targeting": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-3.1.0.tgz",
+      "integrity": "sha512-aXAa1Pv6w32URacE9LfMsl9zI6hFwx1K0Lp3Xpyf4rAkmaAB6z0gOkhicOrVFc0f64YheJgHjE7hJFieVenQdw=="
+    },
+    "@material/floating-label": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-4.0.0.tgz",
+      "integrity": "sha512-ovuZKhH7U+YmZk8kXftYCdEaU9InJdkBsPe4TP+dg4HiO1lWmd7ZxVsMo6iTl4yaFofkBPj3VDkbE1fLnHxKPA==",
+      "requires": {
+        "@material/animation": "^4.0.0",
+        "@material/base": "^4.0.0",
+        "@material/rtl": "^4.0.0",
+        "@material/theme": "^4.0.0",
+        "@material/typography": "^4.0.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@material/animation": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/animation/-/animation-4.0.0.tgz",
+          "integrity": "sha512-IfzXzstWdtKQcsNWu+s2Hpz5dBwkTHtgtzoesr+FC7TqENH+SJdsF1ntnZI1XVi2C9ZlBf7f4BSmXpWHD0MIlw==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/base": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/base/-/base-4.0.0.tgz",
+          "integrity": "sha512-vHm7fkqXzjdfxifXvlmaZColoIfKuWmO+1rvdzDORTWP+A8Dq70cgKd2I1SBqxzDGjOasMzHbQI6f9MISQf2vQ==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-4.0.0.tgz",
+          "integrity": "sha512-0gk+f151vqmEdWkrQ9ocPlQRU9aUtSGsVBhletqIbsthLUsZIz9qk25FHjV1wHd/bGHknd9NH+T8ENprv3KLFg=="
+        },
+        "@material/rtl": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-4.0.0.tgz",
+          "integrity": "sha512-AP8zByVDEWAJVJoxByVccUbH+BX24IeG7ol+L6Qd8JjzPpz1fzPVJ4BeDNaF0a6sXtHsRmj2zN5dsx/BGC3IHg=="
+        },
+        "@material/theme": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-4.0.0.tgz",
+          "integrity": "sha512-vS4G4rusJTatTH50kSYO1U3UGN8EY9kGRvPaFsEFKikJBOqcR6KWK9H9/wCLqqd6nDNifEj9H2sdWw1AV4NA6Q==",
+          "requires": {
+            "@material/feature-targeting": "^4.0.0"
+          }
+        },
+        "@material/typography": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/typography/-/typography-4.0.0.tgz",
+          "integrity": "sha512-lUG4yjG9fl1ryNX4OVnOmi+EjhiV4WsWcYt4yzffHrFg1RfKuCAV59j7TtmlMfZIkNDwqK5jvk3oOpTRDFpL8Q==",
+          "requires": {
+            "@material/feature-targeting": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@material/line-ripple": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-4.0.0.tgz",
+      "integrity": "sha512-+vrgKlb2gUBIKxlzVKLn/tX76qJ0Z19RkH2i7mh4IdH8KxeEai8NQQYWqeOOKtyp8JbH0ObGyqJCwPo2VbHDmw==",
+      "requires": {
+        "@material/animation": "^4.0.0",
+        "@material/base": "^4.0.0",
+        "@material/theme": "^4.0.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@material/animation": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/animation/-/animation-4.0.0.tgz",
+          "integrity": "sha512-IfzXzstWdtKQcsNWu+s2Hpz5dBwkTHtgtzoesr+FC7TqENH+SJdsF1ntnZI1XVi2C9ZlBf7f4BSmXpWHD0MIlw==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/base": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/base/-/base-4.0.0.tgz",
+          "integrity": "sha512-vHm7fkqXzjdfxifXvlmaZColoIfKuWmO+1rvdzDORTWP+A8Dq70cgKd2I1SBqxzDGjOasMzHbQI6f9MISQf2vQ==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-4.0.0.tgz",
+          "integrity": "sha512-0gk+f151vqmEdWkrQ9ocPlQRU9aUtSGsVBhletqIbsthLUsZIz9qk25FHjV1wHd/bGHknd9NH+T8ENprv3KLFg=="
+        },
+        "@material/theme": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-4.0.0.tgz",
+          "integrity": "sha512-vS4G4rusJTatTH50kSYO1U3UGN8EY9kGRvPaFsEFKikJBOqcR6KWK9H9/wCLqqd6nDNifEj9H2sdWw1AV4NA6Q==",
+          "requires": {
+            "@material/feature-targeting": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@material/notched-outline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-4.0.0.tgz",
+      "integrity": "sha512-9WNG7dZS83nu72kmoknA3XyvZQIxx8QBjEB2Q2KGyRp4Q8zrzWxfcvTYgiOsYgvz013JnTqaqe4g0wjl6v789g==",
+      "requires": {
+        "@material/base": "^4.0.0",
+        "@material/floating-label": "^4.0.0",
+        "@material/rtl": "^4.0.0",
+        "@material/shape": "^4.0.0",
+        "@material/theme": "^4.0.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@material/base": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/base/-/base-4.0.0.tgz",
+          "integrity": "sha512-vHm7fkqXzjdfxifXvlmaZColoIfKuWmO+1rvdzDORTWP+A8Dq70cgKd2I1SBqxzDGjOasMzHbQI6f9MISQf2vQ==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-4.0.0.tgz",
+          "integrity": "sha512-0gk+f151vqmEdWkrQ9ocPlQRU9aUtSGsVBhletqIbsthLUsZIz9qk25FHjV1wHd/bGHknd9NH+T8ENprv3KLFg=="
+        },
+        "@material/rtl": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-4.0.0.tgz",
+          "integrity": "sha512-AP8zByVDEWAJVJoxByVccUbH+BX24IeG7ol+L6Qd8JjzPpz1fzPVJ4BeDNaF0a6sXtHsRmj2zN5dsx/BGC3IHg=="
+        },
+        "@material/shape": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/shape/-/shape-4.0.0.tgz",
+          "integrity": "sha512-wmr05YBrEL462QPiJ+t9xh5RqxzylXYo/8DVZnb/1WA9GZ6m38UK/8Awtip1cZAN34pzD/9p5AydyywlQVoI+g==",
+          "requires": {
+            "@material/feature-targeting": "^4.0.0"
+          }
+        },
+        "@material/theme": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-4.0.0.tgz",
+          "integrity": "sha512-vS4G4rusJTatTH50kSYO1U3UGN8EY9kGRvPaFsEFKikJBOqcR6KWK9H9/wCLqqd6nDNifEj9H2sdWw1AV4NA6Q==",
+          "requires": {
+            "@material/feature-targeting": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@material/ripple": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-3.2.0.tgz",
+      "integrity": "sha512-GtwkfNakALmfGLs6TpdFIVeAWjRqbyT7WfEw9aU7elUokABfHES+O0KoSKQSMQiSQ8Vjl90MONzNsN1Evi/1YQ==",
+      "requires": {
+        "@material/animation": "^3.1.0",
+        "@material/base": "^3.1.0",
+        "@material/dom": "^3.1.0",
+        "@material/feature-targeting": "^3.1.0",
+        "@material/theme": "^3.1.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@material/rtl": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-3.2.0.tgz",
+      "integrity": "sha512-L/w9m9Yx1ceOw/VjEfeJoqD4rW9QP3IBb9MamXAg3qUi/zsztoXD/FUw179pxkLn4huFFNlVYZ4Y1y6BpM0PMA=="
+    },
+    "@material/shape": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-3.1.0.tgz",
+      "integrity": "sha512-Oyvs7YjHfByA0e9IVVp7ojAlPwgSu3Bl0cioiE0OdkidkAaNu0izM2ryRzMBDH5o8+lRD0kpZoT+9CVVCdaYIg==",
+      "requires": {
+        "@material/feature-targeting": "^3.1.0"
+      }
+    },
+    "@material/textfield": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-4.0.0.tgz",
+      "integrity": "sha512-1Xg+nriTqFB8+5k8sGkR8LBeD3dRgNuhvwyU8XrUeAs5l/HMfn4CWgbEyZTaJ2EEtFPxnKGedAYqCEwXngwGWg==",
+      "requires": {
+        "@material/animation": "^4.0.0",
+        "@material/base": "^4.0.0",
+        "@material/density": "^4.0.0",
+        "@material/dom": "^4.0.0",
+        "@material/floating-label": "^4.0.0",
+        "@material/line-ripple": "^4.0.0",
+        "@material/notched-outline": "^4.0.0",
+        "@material/ripple": "^4.0.0",
+        "@material/rtl": "^4.0.0",
+        "@material/shape": "^4.0.0",
+        "@material/theme": "^4.0.0",
+        "@material/typography": "^4.0.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@material/animation": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/animation/-/animation-4.0.0.tgz",
+          "integrity": "sha512-IfzXzstWdtKQcsNWu+s2Hpz5dBwkTHtgtzoesr+FC7TqENH+SJdsF1ntnZI1XVi2C9ZlBf7f4BSmXpWHD0MIlw==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/base": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/base/-/base-4.0.0.tgz",
+          "integrity": "sha512-vHm7fkqXzjdfxifXvlmaZColoIfKuWmO+1rvdzDORTWP+A8Dq70cgKd2I1SBqxzDGjOasMzHbQI6f9MISQf2vQ==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/dom": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/dom/-/dom-4.0.0.tgz",
+          "integrity": "sha512-GRCJT9+PGWqygZwGf1XLTrbmzP35YWG7+T0hpfhoIJO8VDiMTeyfvhJXFuA2wh9pD0noEjte0lmbdBlykrbWZw==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-4.0.0.tgz",
+          "integrity": "sha512-0gk+f151vqmEdWkrQ9ocPlQRU9aUtSGsVBhletqIbsthLUsZIz9qk25FHjV1wHd/bGHknd9NH+T8ENprv3KLFg=="
+        },
+        "@material/ripple": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-4.0.0.tgz",
+          "integrity": "sha512-9BLIOvyCP5sM+fQpLlcJZWyrHguusJq8E5A1pxg0wQwputOyaPBM7recHhYkJmVjzRpTcPgf1PkvkpN6DKGcNg==",
+          "requires": {
+            "@material/animation": "^4.0.0",
+            "@material/base": "^4.0.0",
+            "@material/dom": "^4.0.0",
+            "@material/feature-targeting": "^4.0.0",
+            "@material/theme": "^4.0.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/rtl": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-4.0.0.tgz",
+          "integrity": "sha512-AP8zByVDEWAJVJoxByVccUbH+BX24IeG7ol+L6Qd8JjzPpz1fzPVJ4BeDNaF0a6sXtHsRmj2zN5dsx/BGC3IHg=="
+        },
+        "@material/shape": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/shape/-/shape-4.0.0.tgz",
+          "integrity": "sha512-wmr05YBrEL462QPiJ+t9xh5RqxzylXYo/8DVZnb/1WA9GZ6m38UK/8Awtip1cZAN34pzD/9p5AydyywlQVoI+g==",
+          "requires": {
+            "@material/feature-targeting": "^4.0.0"
+          }
+        },
+        "@material/theme": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-4.0.0.tgz",
+          "integrity": "sha512-vS4G4rusJTatTH50kSYO1U3UGN8EY9kGRvPaFsEFKikJBOqcR6KWK9H9/wCLqqd6nDNifEj9H2sdWw1AV4NA6Q==",
+          "requires": {
+            "@material/feature-targeting": "^4.0.0"
+          }
+        },
+        "@material/typography": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@material/typography/-/typography-4.0.0.tgz",
+          "integrity": "sha512-lUG4yjG9fl1ryNX4OVnOmi+EjhiV4WsWcYt4yzffHrFg1RfKuCAV59j7TtmlMfZIkNDwqK5jvk3oOpTRDFpL8Q==",
+          "requires": {
+            "@material/feature-targeting": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@material/theme": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-3.1.0.tgz",
+      "integrity": "sha512-N4JX+akOwg1faAvFvIEhDcwW4cZfUpwEn8lct6Vs3WczjLF6/KdIoLVaYh+eVl1bzfsoIuWvx56j0B1PjXZw9g==",
+      "requires": {
+        "@material/feature-targeting": "^3.1.0"
+      }
+    },
+    "@material/typography": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-3.1.0.tgz",
+      "integrity": "sha512-aSNBQvVxIH1kORSYdLGuSTivx6oJ1MSOSTUAsUwhXPQLQlvbdFeZaqUp7xgn+EvRsHGRFhWk5YGuiBds9+7zQg==",
+      "requires": {
+        "@material/feature-targeting": "^3.1.0"
+      }
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    }
+  }
+}


### PR DESCRIPTION
NPM lockfiles are a bit different from yarn's, so I think long term it'd be nice to build up a package manager agnostic graph and do diffing on that, and also be able to provide some better feedback on where things are wrong (like which if your top level dependencies cause the duplication). 