### PR TITLE
Improve perf for very large workspaces

### DIFF
--- a/src/commands/yarn-workspace.js
+++ b/src/commands/yarn-workspace.js
@@ -146,15 +146,18 @@ exports.handler = function(argv) {
     });
   }
 
-  const versions = allowlist
-    .map(packageName =>
-      [
+  const versions = Array.from(
+    allowlist.reduce(
+      (acc, packageName) =>
+        getWorkspaceDependencies(packageName, packages, acc),
+      new Set()
+    )
+  )
+    .map(packageName => getPackageDependencies(packages.get(packageName)))
+    .concat(
+      allowlist.map(packageName => [
         getPackageDependencies(packages.get(packageName), dependencyGroups),
-      ].concat(
-        Array.from(
-          getWorkspaceDependencies(packageName, packages)
-        ).map(packageName => getPackageDependencies(packages.get(packageName)))
-      )
+      ])
     )
     .reduce((acc, arr) => Array.from(new Set(acc.concat(arr))), [])
     .map(omit(packageNames))

--- a/src/printResult.js
+++ b/src/printResult.js
@@ -11,9 +11,9 @@ function printResult(duplicates, isYarn = false) {
     );
     [...duplicates.entries()].sort().forEach(([packageName, versions]) => {
       console.warn(
-        `${chalk.bold(packageName)} with versions ${Array.from(versions).join(
-          ', '
-        )}.`
+        `${chalk.bold(packageName)} with versions ${Array.from(versions)
+          .sort()
+          .join(', ')}.`
       );
     });
     if (isYarn) {

--- a/test/yarn-workspace.spec.js
+++ b/test/yarn-workspace.spec.js
@@ -150,7 +150,7 @@ describe('diglett workspace', () => {
       ]);
       expect(stripAnsi(stderr)).toMatchInlineSnapshot(`
         "Found 1 duplicate dependency
-        @material/textfield with versions 3.2.0, 4.0.0, 3.1.0.
+        @material/textfield with versions 3.1.0, 3.2.0, 4.0.0.
         "
       `);
     });


### PR DESCRIPTION
This small change will make sure expensive traversal is not duplicated which means large performance gains in very large workspaces with thousands of packages and long dependency chains. 