### PR TITLE
Add support for single char packages in yarn berry

### DIFF
--- a/src/parseYarnDescriptor.js
+++ b/src/parseYarnDescriptor.js
@@ -1,7 +1,7 @@
 /**
  * A regular expression for parsing a yarn berry descriptor.
  */
-const PARSE_REGEX = /(^@?[^/]+?\/?[^@/]+?)@(?:.*:)*(.+)/;
+const PARSE_REGEX = /(?<packageName>(^@?[^/]+?\/)?[^@/]+?)@(?:.*:)*(?<version>.+)/;
 
 /**
  * @typedef {Object} ParsedDescriptor
@@ -39,7 +39,8 @@ function parseYarnDescriptor(descriptor) {
   if (!result) {
     throw new Error(`Unable to parse descriptor: ${descriptor}`);
   }
-  const [, packageName, version] = result;
+
+  const { packageName, version } = result.groups;
   return { packageName, version };
 }
 

--- a/test/parse-yarn-descriptor.spec.js
+++ b/test/parse-yarn-descriptor.spec.js
@@ -29,6 +29,13 @@ describe('parse-yarn-descriptor', () => {
     });
   });
 
+  it('should parse a single char yarn berry descriptor with protocol', () => {
+    expect(parseYarnDescriptor('q@npm:1.0.0')).toEqual({
+      packageName: 'q',
+      version: '1.0.0',
+    });
+  });
+
   it('should throw an error if the descriptor is invalid', () => {
     expect(() => parseYarnDescriptor('invalid')).toThrow();
   });


### PR DESCRIPTION
There is an edge case in the regex, if the package name is exactly one character long.